### PR TITLE
Fix invalid npm package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   }],
   "dependencies": {
     "escape-string-regexp": "^1.0.3",
-    "vinyl-map": "git+https://github.com/hughsk/vinyl-map.git#4171258696800b8151bfe0cfec7650aca0a78985"
+    "vinyl-map": "1.0.1"
   }
 }


### PR DESCRIPTION
`vinyl-map` package was pointing to an invalid git commit, which resulted in failure in newer versions of `npm`.
Old version of `npm` silently failed and installed `1.0.1` version instead.